### PR TITLE
fix: docker rm에 -f 옵션 추가하여 컨테이너 삭제 실패 방지

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -89,7 +89,7 @@ jobs:
 
             # Stop and remove existing container (ignore errors if not exists)
             sudo docker stop mechuragi-server 2>/dev/null || echo "Container not running, skipping stop"
-            sudo docker rm mechuragi-server 2>/dev/null || echo "Container not found, skipping removal"
+            sudo docker rm -f mechuragi-server 2>/dev/null || echo "Container not found, skipping removal"
 
             # Run new container with environment variables and IAM role access
             sudo docker run -d \


### PR DESCRIPTION
## 📋 변경 사항
- GitHub Actions 배포 스크립트에서
docker rm 명령어에 -f 옵션을 추가하여
컨테이너 삭제 시 충돌(Conflict. The container name is already in use) 문제를 방지했습니다.

- 배포 시 기존 컨테이너가 정상적으로 종료되지 않아 발생하던
“Container name already in use” 오류를 해결했습니다.

## 🔗 관련 이슈
- Closes #

## ✅ 체크리스트
- [ ] 기능이 정상적으로 동작함을 확인했습니다
- [ ] 코드 리뷰를 요청할 준비가 되었습니다
- [ ] 테스트를 진행했습니다

## 📝 추가 정보
- 이 수정은 배포 로직에만 영향을 주며, 애플리케이션 코드에는 변경이 없습니다.
- EC2 환경에서 docker rm -f 명령으로 컨테이너를 강제 제거하도록 변경했습니다.
- 이후 배포 시 기존 컨테이너 충돌로 인한 배포 실패가 발생하지 않습니다.