### PR TITLE
feat: 음식 취향 활성화 토글 및 첫 취향 자동 활성화 기능 추가 (#27)

### DIFF
--- a/src/main/java/com/mechuragi/mechuragi_server/domain/preference/controller/FoodPreferenceController.java
+++ b/src/main/java/com/mechuragi/mechuragi_server/domain/preference/controller/FoodPreferenceController.java
@@ -91,4 +91,15 @@ public class FoodPreferenceController {
         foodPreferenceService.deletePreference(memberId, preferenceId);
         return ResponseEntity.noContent().build();
     }
+
+    // 음식 취향 활성화 토글
+    @PatchMapping("/{preferenceId}/toggle-active")
+    public ResponseEntity<Void> toggleActivePreference(
+            HttpServletRequest request,
+            @PathVariable Long preferenceId) {
+
+        Long memberId = getMemberIdFromRequest(request);
+        foodPreferenceService.toggleActivePreference(memberId, preferenceId);
+        return ResponseEntity.ok().build();
+    }
 }

--- a/src/main/java/com/mechuragi/mechuragi_server/domain/preference/service/FoodPreferenceService.java
+++ b/src/main/java/com/mechuragi/mechuragi_server/domain/preference/service/FoodPreferenceService.java
@@ -28,10 +28,13 @@ public class FoodPreferenceService {
     public Long createPreference(Member member, CreatePreferenceRequest request) {
         String preferenceName = generatePreferenceName(member, request.getPreferenceName());
 
+        // 첫 번째 취향이면 자동 활성화
+        boolean isFirstPreference = foodPreferenceRepository.countByMemberId(member.getId()) == 0;
+
         FoodPreference preference = FoodPreference.builder()
                 .member(member)
                 .preferenceName(preferenceName)
-                .isActive(false)
+                .isActive(isFirstPreference)
                 .numberOfDiners(request.getNumberOfDiners())
                 .allergyInfo(request.getAllergyInfo())
                 .isOnDiet(request.getIsOnDiet())
@@ -193,5 +196,25 @@ public class FoodPreferenceService {
     public FoodPreference findActivePreference(Member member) {
         return foodPreferenceRepository.findByMemberAndIsActiveTrue(member)
                 .orElseThrow(() -> new BusinessException(ErrorCode.PREFERENCE_NOT_FOUND));
+    }
+
+    // 음식 취향 활성화 토글 (한 번에 하나만 활성화)
+    @Transactional
+    public void toggleActivePreference(Long memberId, Long preferenceId) {
+        // 해당 취향이 사용자 소유인지 확인
+        FoodPreference targetPreference = foodPreferenceRepository.findByIdAndMemberId(preferenceId, memberId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.PREFERENCE_NOT_FOUND));
+
+        // 사용자의 모든 취향 조회
+        List<FoodPreference> allPreferences = foodPreferenceRepository.findByMemberIdOrderByCreatedAtDesc(memberId);
+
+        // 선택한 취향만 활성화, 나머지는 비활성화
+        allPreferences.forEach(preference -> {
+            if (preference.getId().equals(preferenceId)) {
+                preference.activate();
+            } else {
+                preference.deactivate();
+            }
+        });
     }
 }


### PR DESCRIPTION
 ## 📋 변경 사항
  음식 취향 활성화 토글 기능 및 첫 번째 취향 자동 활성화 로직을 추가하여
  사용자 경험을 개선했습니다.

  ### 주요 변경 내용
  1. **취향 활성화 토글 API 추가**
     - `PATCH /api/food-preferences/{preferenceId}/toggle-active` 엔드포인트
   구현
     - 한 번에 하나의 취향만 활성화 가능 (라디오 버튼 방식)

  2. **첫 번째 취향 자동 활성화**
     - 사용자의 첫 취향 생성 시 `isActive=true`로 자동 설정
     - 추가 취향은 기본적으로 비활성화 상태로 생성

  3. **비즈니스 로직 개선**
     - `FoodPreferenceService.toggleActivePreference()` 메서드 추가
     - 소유권 검증 및 일괄 상태 업데이트 처리

  ### 코드 변경
  - `FoodPreferenceController.java`: 토글 엔드포인트 추가
  - `FoodPreferenceService.java`: 토글 로직 및 자동 활성화 로직 구현

  ## 🔗 관련 이슈
  - Closes #27

  ## ✅ 체크리스트
  - [x] 기능이 정상적으로 동작함을 확인했습니다
  - [x] 코드 리뷰를 요청할 준비가 되었습니다
  - [x] 테스트를 진행했습니다

  ## 📝 추가 정보
  ### API 사용 예시
  ```bash
  # 음식 취향 활성화 토글
  PATCH /api/food-preferences/{preferenceId}/toggle-active
  Authorization: Bearer {JWT_TOKEN}

  # Response: 200 OK

  동작 방식

  - 사용자가 취향 A를 활성화하면 → 기존에 활성화된 취향 B는 자동으로 비활성화
  - 첫 번째 취향 생성 → 자동으로 활성화 (isActive=true)
  - 두 번째 이후 취향 생성 → 비활성화 상태 (isActive=false)