### PR TITLE
feat: 먹방 일기 기능 구현 (#36)

### DIFF
--- a/src/main/java/com/mechuragi/mechuragi_server/domain/diary/controller/FoodDiaryController.java
+++ b/src/main/java/com/mechuragi/mechuragi_server/domain/diary/controller/FoodDiaryController.java
@@ -1,0 +1,90 @@
+package com.mechuragi.mechuragi_server.domain.diary.controller;
+
+import com.mechuragi.mechuragi_server.auth.dto.CustomUserDetails;
+import com.mechuragi.mechuragi_server.domain.diary.dto.*;
+import com.mechuragi.mechuragi_server.domain.diary.service.FoodDiaryService;
+import com.mechuragi.mechuragi_server.global.service.S3Service;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.net.URI;
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/diaries")
+@RequiredArgsConstructor
+@Tag(name = "먹방 일기", description = "먹방 일기 관리 API")
+public class FoodDiaryController {
+
+    private final FoodDiaryService foodDiaryService;
+    private final S3Service s3Service;
+
+    @PostMapping
+    @Operation(summary = "먹방 일기 등록", description = "새로운 먹방 일기를 작성합니다.")
+    public ResponseEntity<DiaryResponseDTO> createDiary(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @Valid @RequestBody CreateDiaryRequestDTO diaryRequest) {
+
+        DiaryResponseDTO response = foodDiaryService.createDiary(userDetails.getMemberId(), diaryRequest);
+        return ResponseEntity
+                .created(URI.create("/api/diaries/" + response.getId()))
+                .body(response);
+    }
+
+    @GetMapping("/calendar")
+    @Operation(summary = "먹방 일기 캘린더 조회", description = "특정 년월의 일기 목록을 캘린더 형식으로 조회합니다.")
+    public ResponseEntity<DiaryCalendarResponseDTO> getMonthlyDiaries(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestParam int year,
+            @RequestParam int month) {
+
+        DiaryCalendarResponseDTO response = foodDiaryService.getMonthlyDiaries(userDetails.getMemberId(), year, month);
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/{diaryId}")
+    @Operation(summary = "먹방 일기 상세 조회", description = "특정 먹방 일기의 상세 정보를 조회합니다.")
+    public ResponseEntity<DiaryResponseDTO> getDiaryDetail(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @PathVariable Long diaryId) {
+
+        DiaryResponseDTO response = foodDiaryService.getDiaryDetail(userDetails.getMemberId(), diaryId);
+        return ResponseEntity.ok(response);
+    }
+
+    @PutMapping("/{diaryId}")
+    @Operation(summary = "먹방 일기 수정", description = "자신이 작성한 먹방 일기를 수정합니다.")
+    public ResponseEntity<DiaryResponseDTO> updateDiary(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @PathVariable Long diaryId,
+            @Valid @RequestBody UpdateDiaryRequestDTO updateRequest) {
+
+        DiaryResponseDTO response = foodDiaryService.updateDiary(userDetails.getMemberId(), diaryId, updateRequest);
+        return ResponseEntity.ok(response);
+    }
+
+    @DeleteMapping("/{diaryId}")
+    @Operation(summary = "먹방 일기 삭제", description = "자신이 작성한 먹방 일기를 삭제합니다.")
+    public ResponseEntity<Void> deleteDiary(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @PathVariable Long diaryId) {
+
+        foodDiaryService.deleteDiary(userDetails.getMemberId(), diaryId);
+        return ResponseEntity.noContent().build();
+    }
+
+    @PostMapping(value = "/upload-image", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    @Operation(summary = "먹방 일기 이미지 업로드", description = "먹방 일기에 사용할 이미지를 S3에 업로드합니다.")
+    public ResponseEntity<Map<String, String>> uploadImage(
+            @RequestParam("file") MultipartFile file) {
+        String imageUrl = s3Service.uploadImage(file, "diary");
+        return ResponseEntity.ok(Map.of("imageUrl", imageUrl));
+    }
+}

--- a/src/main/java/com/mechuragi/mechuragi_server/domain/diary/dto/CreateDiaryRequestDTO.java
+++ b/src/main/java/com/mechuragi/mechuragi_server/domain/diary/dto/CreateDiaryRequestDTO.java
@@ -1,0 +1,37 @@
+package com.mechuragi.mechuragi_server.domain.diary.dto;
+
+import jakarta.validation.constraints.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class CreateDiaryRequestDTO {
+
+    @NotBlank(message = "제목은 필수입니다")
+    @Size(max = 100, message = "제목은 100자 이하여야 합니다")
+    private String title;
+
+    @NotBlank(message = "내용은 필수입니다")
+    @Size(max = 2000, message = "내용은 2000자 이하여야 합니다")
+    private String content;
+
+    @NotNull(message = "별점은 필수입니다")
+    @DecimalMin(value = "0.0", message = "별점은 0.0 이상이어야 합니다")
+    @DecimalMax(value = "5.0", message = "별점은 5.0 이하여야 합니다")
+    private BigDecimal rating;
+
+    @NotNull(message = "일기 날짜는 필수입니다")
+    private LocalDate diaryDate;
+
+    @Size(max = 4, message = "이미지는 최대 4장까지 첨부 가능합니다")
+    private List<String> imageUrls;
+}

--- a/src/main/java/com/mechuragi/mechuragi_server/domain/diary/dto/DiaryCalendarResponseDTO.java
+++ b/src/main/java/com/mechuragi/mechuragi_server/domain/diary/dto/DiaryCalendarResponseDTO.java
@@ -1,0 +1,42 @@
+package com.mechuragi.mechuragi_server.domain.diary.dto;
+
+import com.mechuragi.mechuragi_server.domain.diary.entity.FoodDiary;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+import java.util.Comparator;
+import java.util.List;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class DiaryCalendarResponseDTO {
+
+    private final int year;
+    private final int month;
+    private final List<DiaryDateInfo> diaries;
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    public static class DiaryDateInfo {
+        private final Long diaryId;
+        private final LocalDate diaryDate;
+        private final List<String> thumbnails;
+
+        public static DiaryDateInfo from(FoodDiary diary) {
+            List<String> thumbnails = diary.getImages().stream()
+                    .sorted(Comparator.comparing(img -> img.getDisplayOrder()))
+                    .map(img -> img.getImageUrl())
+                    .toList();
+
+            return DiaryDateInfo.builder()
+                    .diaryId(diary.getId())
+                    .diaryDate(diary.getDiaryDate())
+                    .thumbnails(thumbnails)
+                    .build();
+        }
+    }
+}

--- a/src/main/java/com/mechuragi/mechuragi_server/domain/diary/dto/DiaryImageResponseDTO.java
+++ b/src/main/java/com/mechuragi/mechuragi_server/domain/diary/dto/DiaryImageResponseDTO.java
@@ -1,0 +1,24 @@
+package com.mechuragi.mechuragi_server.domain.diary.dto;
+
+import com.mechuragi.mechuragi_server.domain.diary.entity.FoodDiaryImage;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class DiaryImageResponseDTO {
+
+    private final Long id;
+    private final String imageUrl;
+    private final Integer displayOrder;
+
+    public static DiaryImageResponseDTO from(FoodDiaryImage image) {
+        return DiaryImageResponseDTO.builder()
+                .id(image.getId())
+                .imageUrl(image.getImageUrl())
+                .displayOrder(image.getDisplayOrder())
+                .build();
+    }
+}

--- a/src/main/java/com/mechuragi/mechuragi_server/domain/diary/dto/DiaryResponseDTO.java
+++ b/src/main/java/com/mechuragi/mechuragi_server/domain/diary/dto/DiaryResponseDTO.java
@@ -1,0 +1,45 @@
+package com.mechuragi.mechuragi_server.domain.diary.dto;
+
+import com.mechuragi.mechuragi_server.domain.diary.entity.FoodDiary;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Comparator;
+import java.util.List;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class DiaryResponseDTO {
+
+    private final Long id;
+    private final String title;
+    private final String content;
+    private final BigDecimal rating;
+    private final LocalDate diaryDate;
+    private final List<DiaryImageResponseDTO> images;
+    private final LocalDateTime createdAt;
+    private final LocalDateTime updatedAt;
+
+    public static DiaryResponseDTO from(FoodDiary diary) {
+        List<DiaryImageResponseDTO> images = diary.getImages().stream()
+                .sorted(Comparator.comparing(img -> img.getDisplayOrder()))
+                .map(DiaryImageResponseDTO::from)
+                .toList();
+
+        return DiaryResponseDTO.builder()
+                .id(diary.getId())
+                .title(diary.getTitle())
+                .content(diary.getContent())
+                .rating(diary.getRating())
+                .diaryDate(diary.getDiaryDate())
+                .images(images)
+                .createdAt(diary.getCreatedAt())
+                .updatedAt(diary.getUpdatedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/mechuragi/mechuragi_server/domain/diary/dto/UpdateDiaryRequestDTO.java
+++ b/src/main/java/com/mechuragi/mechuragi_server/domain/diary/dto/UpdateDiaryRequestDTO.java
@@ -1,0 +1,33 @@
+package com.mechuragi.mechuragi_server.domain.diary.dto;
+
+import jakarta.validation.constraints.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class UpdateDiaryRequestDTO {
+
+    @NotBlank(message = "제목은 필수입니다")
+    @Size(max = 100, message = "제목은 100자 이하여야 합니다")
+    private String title;
+
+    @NotBlank(message = "내용은 필수입니다")
+    @Size(max = 2000, message = "내용은 2000자 이하여야 합니다")
+    private String content;
+
+    @NotNull(message = "별점은 필수입니다")
+    @DecimalMin(value = "0.0", message = "별점은 0.0 이상이어야 합니다")
+    @DecimalMax(value = "5.0", message = "별점은 5.0 이하여야 합니다")
+    private BigDecimal rating;
+
+    @Size(max = 4, message = "이미지는 최대 4장까지 첨부 가능합니다")
+    private List<String> imageUrls;
+}

--- a/src/main/java/com/mechuragi/mechuragi_server/domain/diary/entity/FoodDiary.java
+++ b/src/main/java/com/mechuragi/mechuragi_server/domain/diary/entity/FoodDiary.java
@@ -1,0 +1,90 @@
+package com.mechuragi.mechuragi_server.domain.diary.entity;
+
+import com.mechuragi.mechuragi_server.domain.member.entity.Member;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Table(name = "food_diaries",
+        indexes = {
+                @Index(name = "idx_member_diary_date", columnList = "member_id, diary_date")
+        },
+        uniqueConstraints = {
+                @UniqueConstraint(name = "uk_member_diary_date", columnNames = {"member_id", "diary_date"})
+        }
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
+public class FoodDiary {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    @Column(nullable = false, length = 100)
+    private String title;
+
+    @Column(nullable = false, columnDefinition = "TEXT")
+    private String content;
+
+    @Column(nullable = false, precision = 2, scale = 1)
+    private BigDecimal rating;
+
+    @Column(nullable = false, name = "diary_date")
+    private LocalDate diaryDate;
+
+    @OneToMany(mappedBy = "foodDiary", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<FoodDiaryImage> images = new ArrayList<>();
+
+    @CreatedDate
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(nullable = false)
+    private LocalDateTime updatedAt;
+
+    @Builder
+    public FoodDiary(Member member, String title, String content, BigDecimal rating, LocalDate diaryDate) {
+        this.member = member;
+        this.title = title;
+        this.content = content;
+        this.rating = rating;
+        this.diaryDate = diaryDate;
+    }
+
+    // 일기 수정 (날짜는 변경 불가)
+    public void update(String title, String content, BigDecimal rating) {
+        this.title = title;
+        this.content = content;
+        this.rating = rating;
+    }
+
+    // 이미지 추가
+    public void addImage(FoodDiaryImage image) {
+        this.images.add(image);
+        image.setFoodDiary(this);
+    }
+
+    // 모든 이미지 제거
+    public void clearImages() {
+        this.images.clear();
+    }
+}

--- a/src/main/java/com/mechuragi/mechuragi_server/domain/diary/entity/FoodDiaryImage.java
+++ b/src/main/java/com/mechuragi/mechuragi_server/domain/diary/entity/FoodDiaryImage.java
@@ -1,0 +1,42 @@
+package com.mechuragi.mechuragi_server.domain.diary.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "food_diary_images", indexes = {
+        @Index(name = "idx_diary_id", columnList = "food_diary_id")
+})
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class FoodDiaryImage {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "food_diary_id", nullable = false)
+    private FoodDiary foodDiary;
+
+    @Column(nullable = false, length = 500)
+    private String imageUrl;
+
+    @Column(nullable = false)
+    private Integer displayOrder;
+
+    @Builder
+    public FoodDiaryImage(FoodDiary foodDiary, String imageUrl, Integer displayOrder) {
+        this.foodDiary = foodDiary;
+        this.imageUrl = imageUrl;
+        this.displayOrder = displayOrder;
+    }
+
+    // 양방향 관계 설정용 (package-private으로 제한)
+    void setFoodDiary(FoodDiary foodDiary) {
+        this.foodDiary = foodDiary;
+    }
+}

--- a/src/main/java/com/mechuragi/mechuragi_server/domain/diary/repository/FoodDiaryRepository.java
+++ b/src/main/java/com/mechuragi/mechuragi_server/domain/diary/repository/FoodDiaryRepository.java
@@ -1,0 +1,38 @@
+package com.mechuragi.mechuragi_server.domain.diary.repository;
+
+import com.mechuragi.mechuragi_server.domain.diary.entity.FoodDiary;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface FoodDiaryRepository extends JpaRepository<FoodDiary, Long> {
+
+    // 특정 사용자의 일기 조회 (권한 체크용)
+    Optional<FoodDiary> findByIdAndMemberId(Long id, Long memberId);
+
+    // 특정 년월의 일기 목록 조회 (캘린더용)
+    @Query("SELECT DISTINCT fd FROM FoodDiary fd " +
+           "LEFT JOIN FETCH fd.images " +
+           "WHERE fd.member.id = :memberId " +
+           "AND YEAR(fd.diaryDate) = :year " +
+           "AND MONTH(fd.diaryDate) = :month " +
+           "ORDER BY fd.diaryDate DESC")
+    List<FoodDiary> findByMemberIdAndYearMonth(@Param("memberId") Long memberId,
+                                                 @Param("year") int year,
+                                                 @Param("month") int month);
+
+    // 특정 날짜의 일기 조회 (하루에 하나만 존재)
+    Optional<FoodDiary> findByMemberIdAndDiaryDate(Long memberId, LocalDate diaryDate);
+
+    // 일기 상세 조회 (이미지 함께 fetch)
+    @Query("SELECT fd FROM FoodDiary fd " +
+           "LEFT JOIN FETCH fd.images " +
+           "WHERE fd.id = :id")
+    Optional<FoodDiary> findByIdWithImages(@Param("id") Long id);
+}

--- a/src/main/java/com/mechuragi/mechuragi_server/domain/diary/service/FoodDiaryService.java
+++ b/src/main/java/com/mechuragi/mechuragi_server/domain/diary/service/FoodDiaryService.java
@@ -1,0 +1,171 @@
+package com.mechuragi.mechuragi_server.domain.diary.service;
+
+import com.mechuragi.mechuragi_server.domain.diary.dto.*;
+import com.mechuragi.mechuragi_server.domain.diary.entity.FoodDiary;
+import com.mechuragi.mechuragi_server.domain.diary.entity.FoodDiaryImage;
+import com.mechuragi.mechuragi_server.domain.diary.repository.FoodDiaryRepository;
+import com.mechuragi.mechuragi_server.domain.diary.validator.RatingValidator;
+import com.mechuragi.mechuragi_server.domain.member.entity.Member;
+import com.mechuragi.mechuragi_server.domain.member.repository.MemberRepository;
+import com.mechuragi.mechuragi_server.global.exception.BusinessException;
+import com.mechuragi.mechuragi_server.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+@Transactional(readOnly = true)
+public class FoodDiaryService {
+
+    private final FoodDiaryRepository foodDiaryRepository;
+    private final MemberRepository memberRepository;
+
+    // 일기 등록
+    @Transactional
+    public DiaryResponseDTO createDiary(Long memberId, CreateDiaryRequestDTO request) {
+        // 회원 조회
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.MEMBER_NOT_FOUND));
+
+        // 별점 검증
+        if (!RatingValidator.isValid(request.getRating())) {
+            throw new BusinessException(ErrorCode.INVALID_RATING);
+        }
+
+        // 미래 날짜 검증
+        if (request.getDiaryDate().isAfter(LocalDate.now())) {
+            throw new BusinessException(ErrorCode.FUTURE_DATE_NOT_ALLOWED);
+        }
+
+        // 이미지 개수 검증
+        if (request.getImageUrls() != null && request.getImageUrls().size() > 4) {
+            throw new BusinessException(ErrorCode.TOO_MANY_IMAGES);
+        }
+
+        // 같은 날짜에 일기가 이미 존재하는지 확인
+        foodDiaryRepository.findByMemberIdAndDiaryDate(memberId, request.getDiaryDate())
+                .ifPresent(diary -> {
+                    throw new BusinessException(ErrorCode.DUPLICATE_DIARY_DATE);
+                });
+
+        // 일기 생성
+        FoodDiary diary = FoodDiary.builder()
+                .member(member)
+                .title(request.getTitle())
+                .content(request.getContent())
+                .rating(request.getRating())
+                .diaryDate(request.getDiaryDate())
+                .build();
+
+        // 이미지 추가
+        if (request.getImageUrls() != null && !request.getImageUrls().isEmpty()) {
+            for (int i = 0; i < request.getImageUrls().size(); i++) {
+                FoodDiaryImage image = FoodDiaryImage.builder()
+                        .imageUrl(request.getImageUrls().get(i))
+                        .displayOrder(i)
+                        .build();
+                diary.addImage(image);
+            }
+        }
+
+        try {
+            FoodDiary savedDiary = foodDiaryRepository.save(diary);
+            log.info("일기 등록 성공 - diaryId: {}, memberId: {}, date: {}", savedDiary.getId(), memberId, request.getDiaryDate());
+            return DiaryResponseDTO.from(savedDiary);
+        } catch (DataIntegrityViolationException e) {
+            log.error("일기 등록 실패 - 중복 날짜: memberId={}, date={}", memberId, request.getDiaryDate());
+            throw new BusinessException(ErrorCode.DUPLICATE_DIARY_DATE);
+        }
+    }
+
+    // 캘린더 월별 조회
+    public DiaryCalendarResponseDTO getMonthlyDiaries(Long memberId, int year, int month) {
+        // 월 범위 검증
+        if (month < 1 || month > 12) {
+            throw new IllegalArgumentException("월은 1~12 사이여야 합니다.");
+        }
+
+        List<FoodDiary> diaries = foodDiaryRepository.findByMemberIdAndYearMonth(memberId, year, month);
+
+        List<DiaryCalendarResponseDTO.DiaryDateInfo> diaryDateInfos = diaries.stream()
+                .map(DiaryCalendarResponseDTO.DiaryDateInfo::from)
+                .toList();
+
+        log.info("캘린더 조회 - memberId: {}, year: {}, month: {}, count: {}", memberId, year, month, diaryDateInfos.size());
+        return DiaryCalendarResponseDTO.builder()
+                .year(year)
+                .month(month)
+                .diaries(diaryDateInfos)
+                .build();
+    }
+
+    // 일기 상세 조회
+    public DiaryResponseDTO getDiaryDetail(Long memberId, Long diaryId) {
+        FoodDiary diary = foodDiaryRepository.findByIdWithImages(diaryId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.DIARY_NOT_FOUND));
+
+        // 권한 체크
+        if (!diary.getMember().getId().equals(memberId)) {
+            throw new BusinessException(ErrorCode.DIARY_ACCESS_DENIED);
+        }
+
+        log.info("일기 상세 조회 - diaryId: {}, memberId: {}", diaryId, memberId);
+        return DiaryResponseDTO.from(diary);
+    }
+
+    // 일기 수정 (날짜는 변경 불가)
+    @Transactional
+    public DiaryResponseDTO updateDiary(Long memberId, Long diaryId, UpdateDiaryRequestDTO request) {
+        // 일기 조회 및 권한 체크
+        FoodDiary diary = foodDiaryRepository.findByIdAndMemberId(diaryId, memberId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.DIARY_NOT_FOUND));
+
+        // 별점 검증
+        if (!RatingValidator.isValid(request.getRating())) {
+            throw new BusinessException(ErrorCode.INVALID_RATING);
+        }
+
+        // 이미지 개수 검증
+        if (request.getImageUrls() != null && request.getImageUrls().size() > 4) {
+            throw new BusinessException(ErrorCode.TOO_MANY_IMAGES);
+        }
+
+        // 일기 내용 수정 (날짜는 변경되지 않음)
+        diary.update(request.getTitle(), request.getContent(), request.getRating());
+
+        // 기존 이미지 모두 삭제
+        diary.clearImages();
+
+        // 새로운 이미지 추가
+        if (request.getImageUrls() != null && !request.getImageUrls().isEmpty()) {
+            for (int i = 0; i < request.getImageUrls().size(); i++) {
+                FoodDiaryImage image = FoodDiaryImage.builder()
+                        .imageUrl(request.getImageUrls().get(i))
+                        .displayOrder(i)
+                        .build();
+                diary.addImage(image);
+            }
+        }
+
+        log.info("일기 수정 성공 - diaryId: {}, memberId: {}", diaryId, memberId);
+        return DiaryResponseDTO.from(diary);
+    }
+
+    // 일기 삭제
+    @Transactional
+    public void deleteDiary(Long memberId, Long diaryId) {
+        // 일기 조회 및 권한 체크
+        FoodDiary diary = foodDiaryRepository.findByIdAndMemberId(diaryId, memberId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.DIARY_NOT_FOUND));
+
+        foodDiaryRepository.delete(diary);
+        log.info("일기 삭제 성공 - diaryId: {}, memberId: {}", diaryId, memberId);
+    }
+}

--- a/src/main/java/com/mechuragi/mechuragi_server/domain/diary/validator/RatingValidator.java
+++ b/src/main/java/com/mechuragi/mechuragi_server/domain/diary/validator/RatingValidator.java
@@ -1,0 +1,27 @@
+package com.mechuragi.mechuragi_server.domain.diary.validator;
+
+import java.math.BigDecimal;
+
+public class RatingValidator {
+
+    private RatingValidator() {
+        // 인스턴스화 방지
+    }
+
+    /**
+     * 별점이 유효한지 검증
+     * - 0.0 ~ 5.0 범위
+     * - 0.5 단위 (0.0, 0.5, 1.0, 1.5, ..., 5.0)
+     */
+    public static boolean isValid(BigDecimal rating) {
+        if (rating == null) {
+            return false;
+        }
+        if (rating.compareTo(BigDecimal.ZERO) < 0 || rating.compareTo(new BigDecimal("5.0")) > 0) {
+            return false;
+        }
+        // 0.5 단위 검증 (0.0, 0.5, 1.0, 1.5, ..., 5.0)
+        BigDecimal doubled = rating.multiply(new BigDecimal("2"));
+        return doubled.remainder(BigDecimal.ONE).compareTo(BigDecimal.ZERO) == 0;
+    }
+}

--- a/src/main/java/com/mechuragi/mechuragi_server/global/exception/ErrorCode.java
+++ b/src/main/java/com/mechuragi/mechuragi_server/global/exception/ErrorCode.java
@@ -41,6 +41,14 @@ public enum ErrorCode {
     FILE_UPLOAD_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "F004", "파일 업로드에 실패했습니다."),
     INVALID_FILE_URL(HttpStatus.BAD_REQUEST, "F005", "유효하지 않은 파일 URL입니다."),
 
+    // Diary
+    DIARY_NOT_FOUND(HttpStatus.NOT_FOUND, "D001", "일기를 찾을 수 없습니다."),
+    DIARY_ACCESS_DENIED(HttpStatus.FORBIDDEN, "D002", "해당 일기에 접근할 권한이 없습니다."),
+    INVALID_RATING(HttpStatus.BAD_REQUEST, "D003", "별점은 0.0에서 5.0 사이여야 하며, 0.5 단위로만 입력 가능합니다."),
+    DUPLICATE_DIARY_DATE(HttpStatus.BAD_REQUEST, "D004", "해당 날짜에 이미 일기가 존재합니다."),
+    TOO_MANY_IMAGES(HttpStatus.BAD_REQUEST, "D005", "이미지는 최대 4장까지 첨부 가능합니다."),
+    FUTURE_DATE_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "D006", "미래 날짜에는 일기를 작성할 수 없습니다."),
+
     // Common
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "C001", "서버 내부 오류가 발생했습니다");
 


### PR DESCRIPTION
## 📋 변경 사항
  먹방 일기 기능을 구현했습니다.

  ### 주요 기능
  - **일기 등록**: 제목, 내용, 별점(0.5 단위), 날짜, 이미지(최대 4장)
  - **캘린더 조회**: 월별로 작성한 일기 목록을 썸네일과 함께 조회
  - **일기 상세 조회**: 작성한 일기의 전체 내용 및 이미지 확인
  - **일기 수정**: 날짜를 제외한 모든 정보 수정 가능
  - **일기 삭제**: 본인이 작성한 일기만 삭제 가능
  - **이미지 업로드**: S3에 이미지 업로드 후 URL 반환

  ## 🔗 관련 이슈
  - Closes #36 

  ## ✅ 체크리스트
  - [x] 기능이 정상적으로 동작함을 확인했습니다
  - [x] 코드 리뷰를 요청할 준비가 되었습니다
  - [x] 빌드 테스트를 진행했습니다

  ## 📝 추가 정보
  ### 구현 파일 목록
  - **Entity**: `FoodDiary.java`, `FoodDiaryImage.java`
  - **DTO**: `CreateDiaryRequestDTO`, `UpdateDiaryRequestDTO`,
  `DiaryResponseDTO`, `DiaryCalendarResponseDTO`, `DiaryImageResponseDTO`
  - **Repository**: `FoodDiaryRepository.java`
  - **Service**: `FoodDiaryService.java`
  - **Controller**: `FoodDiaryController.java`
  - **Validator**: `RatingValidator.java`
  - **ErrorCode**: Diary 관련 에러 6개 추가 (D001~D006)