### PR TITLE
fix: ShedLock 테이블 생성 SQL H2/MySQL 호환으로 변경

### DIFF
--- a/src/main/resources/db/migration/V1__Create_shedlock_table.sql
+++ b/src/main/resources/db/migration/V1__Create_shedlock_table.sql
@@ -1,10 +1,16 @@
 -- ShedLock 테이블 생성
 -- 블루그린 배포 시 스케줄러 중복 실행 방지용
+--
+-- 컬럼 설명:
+--   name: 스케줄러 작업 이름 (PK)
+--   lock_until: 락 만료 시간
+--   locked_at: 락 획득 시간
+--   locked_by: 락을 획득한 인스턴스 식별자
 
 CREATE TABLE IF NOT EXISTS shedlock (
-    name VARCHAR(64) NOT NULL COMMENT '스케줄러 작업 이름',
-    lock_until TIMESTAMP(3) NOT NULL COMMENT '락 만료 시간',
-    locked_at TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) COMMENT '락 획득 시간',
-    locked_by VARCHAR(255) NOT NULL COMMENT '락을 획득한 인스턴스 식별자',
+    name VARCHAR(64) NOT NULL,
+    lock_until TIMESTAMP(3) NOT NULL,
+    locked_at TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+    locked_by VARCHAR(255) NOT NULL,
     PRIMARY KEY (name)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='스케줄러 분산 락 테이블';
+);


### PR DESCRIPTION
## Summary
- PR #42 머지 후 GitHub Actions 테스트 실패 문제 해결
- Flyway 마이그레이션 SQL에서 MySQL 전용 문법 제거
- H2(테스트)와 MySQL(프로덕션) 모두 호환되도록 수정

## 변경 사항
- `COMMENT` 구문 제거 (H2 미지원)
- `ENGINE=InnoDB` 제거 (MySQL 전용)
- `DEFAULT CHARSET=utf8mb4` 제거 (MySQL 전용)
- 컬럼 설명을 SQL 주석으로 이동

## 테스트 결과
✅ 모든 테스트 통과 (21/21)

## 관련 이슈
- Fixes #42 빌드 실패 문제